### PR TITLE
Expose a site as an application

### DIFF
--- a/charts/wordpress-site/templates/application.yaml
+++ b/charts/wordpress-site/templates/application.yaml
@@ -1,0 +1,61 @@
+{{- if (.Capabilities.APIVersions.Has "app.k8s.io/v1beta1") }}
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+    name: {{ include "wordpress-site.fullname" . }}
+    annotations:
+        kubernetes-engine.cloud.google.com/icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAQAAABpN6lAAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAHdElNRQfjAwUPBiqqx2ADAAAPtUlEQVR42s2deXxVxRXHv+8FEiAQSUKQAmJiQcGldaOtQhcRJEJBXLBVW6t1oVWrrcunn09brbWVqkVbl9pSP3VBC9W6VLG4INWqgDRWRaIooqxB2bMiAZLXP5J379xlZs6895LnmX/ucu5vzpw7c+fMmTNzE3QXJajiUKqoZBgVlFNOLwopBlrYw262s50tbGAtH7GSNaS6S6yupiGMYQyjOZx+Dk81sYIaFrOYTd2jiNxTL6q5nfdJZZne4/dMpCjfxXGhnkxmDvVZF11N9dzPJHrmu2h2Gs5NfCIuVjs7aHJQw8fM5PO5FTiX34BxXMXJWsQU63mPd/mAOrZQRwON3r396EMfyjiA4YxgOMMZqs0lxQJu5cXcqiFbSjCNNzRvbRcv8Cuq2c8JsYypzGIZezWorzMl34X2qZrXY4Vcz91MpndW2H2ZyD1sj8VfxoR8Fx0OZn6MaA3MYXwOm1cBY5lNQ0xOCzksf4Xvwyz2RERazgVZvnUd9WZGTLe6h992UX4WGs+HEWEWMK6Lc00ylf9E8l3FN7q38L25g/aQEIs4vtvy/zIvRTrU27rPWDqC2lD2tYzvtsKn6TRWRxrfod2R8dm0hGy0H9Oj24sPUMjVIXuziTO7NssCbgtpfT6fy0vh0zSE50JN4RaSXZVZIX8PdXYX57XwHZTgYpoDcj1Or67IqB+LAtn8l8p8l92jkdQEZHuevrnOYn/+F8hiTn76Xi314K6QqTwwl/CVfKCAt3JevssbS1eyT5HyfQ7MFXAF7ynAjVTnu6Raqg70CqvZPxegJYHKv5HD811KDR3D5dwcMpBqnNxwsVQU+PSty7U7IieU4LuBJhr8HBZmA13APxSwNVTlu6wx1J8XjF6kednYBarZs+kzWfwy3jIWP0WK32YKflbA6Dkq32WNoQRPWIufop2pmYAfodj8rZyQ77LG0ncExU+RYqvBx6ih3oER32fB5I1SkpVCBaR4xXXAdqfy8J/zXVINjREXP0WKmS7Q4xV3x2vZdSRdSDc4KaCNr0qB+yiuhmZG5LucWnrUSQEpaqUzS7OUhy60chcwQDvw6MVg+mRcwBKGGFvuy44KSHFVFCTquh7F216227iWdu9OfxIUUkwpfSmmH6WUUkYJAMuZFJnH/SXXUgC0spOd7KSJRhpopoUmoJm9nXzFFEInajGl9KOMUkopABo4l6c0CniJrzuqtIlD2WhjesZZrx1pdgjniAxxwmmL1pJ7LAO0R8IgYfDqjMd6laHzXH07KijW3FmRAdp0s+M+oZnkkqTLQliD2ZWTGqCfBj0pI7yXTAqYlgFgM++zMNZUOp65vEFdzOyRJLWygaX8jlKttIXscEDzj8fqFfCGGLCeE/gCQ4TuxwoO4wTWipCvZjRVwnH83WJ5P+FF7/gZHdyJTm/oWJGIKv1ahHuzA+JI2oTStgVKd0w83AInBdzirIBDRLgfOc0qPyiWdygLvePH46BGRGb7zGlNBtPfr4mQv+SAWMluobwjlY9mGwelAfxu8EKvQO/wiihrF0E76CER13QHxLXcKeTsxfNex5nkgvDtnkpo0wwuFOl0lrMCBgS+xrq01qlulbJZJO1xwAzvbFPYyP6md6uevuzHpwLIdRk0gidFwn7FCfO7IsyjgWIlJq06XRk66Fse3KM006C1v1Ua5igowIMiLpdGAA/xbwFXI9DCE955YB65SJlQ6DAVvynS6u+dFVAkMl7WO9atUQJjaxAAE7zzHaqfo9q7XNdZJ3qKWtaGDFzOs0WqdY02+aMVsWNEUcAm78oESDcBfwA0v3P4u5d5gmyHcpyzAmSNwDXQ4Qaajfdb2QVAG09715Rhnx97Ndm7dozoTd3urIBETHBVNG10rltmB1mtx+ePd95JXxriXdoVmPR+RyBoXQaN4Fci1Y51RC03jj5926+vYjoN6mgCY7yby/hUgZRU1sHOgnaYr3ZybQTbjY32fe+omaXe8ZiwAl4OCdomyNitywJYzTIRboEjrskmXKUcL1EV0HEh8F1UaJGgqm5yFhR+KGoEX3PGXaLFUs12v4t/BSBBo3dhQAjwPJGg33AWtExkEt/ljHulBqkxYPgO8K7Xk4CDvNP1EcB+oZjA+HS3s6DwuAD3Y+e6NUKDtCDEV+fdOTCpRFcujwA28U9Btqdl0AgkH9hBzo3gA80Sq7Bf8V3v6NCkMuv/QYaC7u/sn4d/sUPA5R73uTT2algBK72jqqTizv4o5tGFfNwlgu7hYQGXe92Kc5XX82boit8nVCYZ5p2siXm4TWQSn5ZBtLCkbg10/sDGvcSnIt2531AOTFLhnXySsaAVGfQEr7FawOVat9bHXIu+Qr+kFUml69saC/kWb3eBoJASOchc61ZT5MpWXohc85t1OcrwUDcFdbWgy9qawaLGg0RuWLeFUQdHno+zD0u8uxthZ+dhu9YJMTgQgqpLE50VQCACVZfucUIcFXk+bsBe6N3dgWfq7DbAPicQ9K/OxR8kUuw2p7oVDpv5UPNa0zm3JL2VNq0GWElrPdU5lOZ0USdXzokOmOWh83nEjzzTpS3yR/MmL9zjFn8LQKmToCAfR7qMN8tC53+3P5JuAnuNXA8IKut9TsWXNYAUKbY71K3rAk/Wavna/CaQLngPY4cjsQamOS1ckzUAgDKHNWlHBs50RlyR58dqVUdGJQbgJBsE72oycnpR+P5TpLhfjBr0Nw7XcPX3ODbACu9kiBH6ZoGgD4gFlTeAFCl2ChtBScCyqNHyVXk8y5Ns8y6bFSBpBKeIG4E/zNmi+Ot01J+TRKhHBT7l+lHMYO9om6oAc0BxbWRMFaX9xOaQ/2V/lDkCfpmprfZD7dGIsHgF+MMHW0S1pA7IuqxBStjqPB5SYhF1dIooGEeNcHvFEBHo1/W1SWUQfIAFfi77rCJMFQnqN4CNLGF9yBsdRyWCRjAgEPpi8jf4TqC1SdZ6J7atCDbzvEBQSZyhX08eph1y1AhOUiZp9vGogdNf+LVGdYrWWbP4tuCLPdeKovYAozvVZne+Nlrrlhov9KyR0w8GGWZ2i4epd+w2FmFBbWtKL/V4fS/kXIFqpznI9j0DZ4XSvSaSpBQ/2hcton9qrFgd1I+TLRxneEd+O5V8YM2NYIpiyO02erNHe0e1pJKgGAz2JQWScaFZ0GAPkKaFGoecSlO1LhuAc5TjBTQYOP38O6fopntV4j9WIRKssVbVFqOgl3l8QVfbbYJGcLoWtTQQLmfujBd7fKd2XPCnx1uNonfQjQJBzzA87y9u/UXg+lECXP3g9mKFq8m4SKO3oipvbbHvmrJbciMFguptMLUHCA9VVlhxm7VFW6hw/c0o/xSPrxbSITJ+p2FfYvieYZCRpsnaDQzO8Eygmohb3P4hLNaMN0sCk2jmmYxTvSMlaHqip5UtAjf0jwR14FuaZ/09gKLrdyTO1/i6dabCscM4cixgi8epjBzUMDn7GtEKQVBafHfpN4C2WMN7oRU3/gM7R+Ewe5FP0CnKd3n9yaoAeMoq6K7YRuCbQPHRyJKYz2jdKmCrct/smfRVdW/wxmTvRqNgscJ0gaBnxTznN4BLYnGLBdsrPhZ5aqxy1xxToJrcocFVD2WGaIZVAb286RR9isbk+w1gn3ZzC3v8/6cR153qq/qDUe4ZiqIisw03Kd2DPVD1LwJBw1so+ibQc1pcyUKos0PPvKvcM0UvJ3jT4/tN9PZwxZ9mD3gYKxD0nNAzvgl0gRa3gI1W3CcCTxyk3DEv4pjk8bX7CyZU+pfHYB/3S+I9nww84TeA1sj0hUq3WHF3B+rWFcod814R/hdIEws/ToGyhz/a4z2Dgl5qy76TJCtOv6Pwq13nkQbc4xU+beyRv2HOQqsCJGuMzlX4/QZwtgX5TSuuX7dKlIC7lUZU//2/pmc6RcnEPtO3xCrofI/XbwAt1n2+rrTi+nXrDOXqLw2YUxS+SXq2hLIpmX21vT3es5X+nbx+A3gEGw3SbqYbrVvqnOUhWsQCZUOQpebMJyqAP7EIKon3PK+T128Ap1kVIFnB/nRnwXzL/n8GPLVOWWu23xfUdy4z0ZM93nNB5ztNN4AGkdv8LCtuK6UEwyGu0aJVKvsNPmnP/BBlqGNbOnWqVdA9lKGaQPcLig+9BVuzn4dqvLUb9o57SlHbwZLs1Z74+0bOQrZZBf0+agOYJBEAuFdUt3wXyqtapAuUZ26UZd5b2ZqsWTvF3EH29dvPKg1AHks2zoq7h2OVs0s1OCMUp/8q+Vab45Q+fonRwXCcQFA/amO2VACSrLMi+5s96AZXRYpN0eYWzHm7kpFpI6UEq6yC+k5Ilw25Zlpx/aQz3dUhm+OWakUsVx6+yMB5nVhMt7UloxwUcH4swuUKx1L3QM7Dlc5jtyFyv0q87N51iV2NEHd37DYbExRzKoPN1CA4FVpvmDaTbmjkusjyciFuXN9+lNKRtlsn67R0q5LNx/FjaOAikZjuGy5InK8p4pxvIxUL0XEbtSAleVgBWq0xNvqLFtvflEH+8wW4zRE/cWUgom1udlttF/KsArZOsz3SIwJBj8wg9zMFuOF4hJGsV+4uyn7T/X6BzZU+4QsxPFOsYq50zhdkztfgXNbRgcpfk5sttgcG+vrtMb15z0C2cen6DPO2OV93Bt7whECQxCplNUyWVBlQwR5+EOG4wyLoyAxz/qoFV53euCLgR1iVu621AQaGdhm7K2QgjzaKaY8w1FGCj4zI6emNIu4JXK/J3dtPU9/A5zDF66GhpWmD059mka9pX4D0VO7I0CZgi4xxzxlTIfMC2eziCuXuz7Ritmf1J4LhBkuzYz3QuaEfLDzWNT9YAEhyc0icf3qzvMO0+3otzSpPWKpVwFgqQxuAtTOz636x0UHjQ3+Ta+H6zoHGixoxr8gyx0s0uHX8ODSZulXscMmKDlDCjDrSW5wMnB8rZpsSmpwZlYsW26d4ObMhTybUg+sjFX4JU2LjPRflIL8nrIVv5/bu/h3j1yO/W0rFDl7sk+12sjlf35ZvmpxL6sk11oCGPdbwWwkVaX64lyJFI1fm6UdPAAwN/IIhmhZknwXQQxs48bBlnUu30IkGl8htWQ5HSpjOg5r3v7TL/23nQF8L2Yl+2stifsNExz++DOV0fsfL2u//slx1eLn86epofs5UA+Jm3qaWddSxifW0KJtr96UXJZRT1ZkOM1TsFE8zS7DGJE/0eWYq4Vb2VK9MXNhTHTdqHXOfIepBNfcJXBkuaQf3MjGfX3t3KmQCt4o2ZDOnWmYxvut+8tD1P18fxBjG8CUOd/rzcAMrqOFVFrO5a8XregX4VMkoqqhkGAMpp5w+9KAf0MQ+drGd7WxmA2tYw0rWdZdQ/wfEXqGEAGDYqgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wMy0wNVQxNDowNjo0MiswMTowMPbcxaEAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDMtMDVUMTQ6MDY6NDIrMDE6MDCHgX0dAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAABJRU5ErkJggg==
+    labels:
+        app: {{ include "wordpress-site.fullname" . }}
+        chart: {{ include "wordpress-site.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+spec:
+    componentKinds:
+        - group: v1
+          kind: Secret
+        - group: v1
+          kind: ClusterRoleBinding
+        - group: v1
+          kind: ServiceAccount
+        - group: v1
+          kind: ConfigMap
+        - group: v1
+          kind: PersistentVolumeClaim
+        - group: v1
+          kind: Service
+        - group: apps
+          kind: Deployment
+        - group: apps
+          kind: StatefulSet
+        - group: batch
+          kind: Job
+        - group: batch
+          kind: CronJob
+    selector:
+        matchLabels:
+            app.kubernetes.io/instance: {{ .Release.Name }}
+    descriptor:
+        type: Wordpress
+        version: {{ .Chart.Version }}
+        description: {{ .Chart.Description }}
+        maintainers:
+            - name: Presslabs
+              url: https://presslabs.com/stack
+        links:
+            - description: Presslabs Wordpress Operator
+              url: https://github.com/presslabs/wordpress-operator
+    info:
+        - name: Ingress IP
+          type: Reference
+          valueFrom:
+            ingressRef:
+              name: {{ .Release.Name }}
+        - name: WP-Admin
+          type: Value
+          {{ if .Values.tls }}
+          value: https://{{ index .Values.site.domains 0 }}/wp-admin/
+          {{ else }}
+          value: http://{{ index .Values.site.domains 0 }}/wp-admin/
+          {{ end }}
+{{- end }}


### PR DESCRIPTION
[Applications](https://github.com/kubernetes-sigs/application#application-objects) are a way for other clients to interact with a chart. More precisely to parse and display meta information regarding a group of resources.

GKE and Openshift support it and hopefully a lot more organizations.
For now, we display the ingress' IP and the wp-admin URL.

Fixes #1 

<img width="789" alt="screenshot 2019-03-05 at 17 06 26" src="https://user-images.githubusercontent.com/639771/53814808-0df84080-3f69-11e9-8a86-f3dcb2bb66a0.png">

#### Tests
- install [stack](https://github.com/presslabs/stack) in a new or existing GKE cluster
- install this chart (you can do it using current values, just add a custom domain, or set your own values)
`helm upgrade --name my-site .`
- go to `GKE` -> `Applications`
- you **should** see `my-site` application
- click on it
- you **should** see the ingress IP, wp-admin url and all resources created for your site
 