### PR TITLE
Enhance media storage

### DIFF
--- a/charts/wordpress-site/templates/wordpress.yaml
+++ b/charts/wordpress-site/templates/wordpress.yaml
@@ -38,13 +38,17 @@ spec:
   media:
     gcs:
       bucket: {{ .Values.media.gcs.bucket }}
+      {{- if .Values.media.gcs.prefix }}
       prefix: {{ default "" .Values.media.gcs.prefix }}
+      {{- end }}
       env:
         - name: GOOGLE_CREDENTIALS
           valueFrom:
             secretKeyRef:
               name: {{ include "wordpress-site.fullname" . }}
               key: google_application_credentials.json
+        - name: GOOGLE_PROJECT_ID
+          value: {{ .Values.media.gcs.project }}
   {{- end }}
   env:
     - name: MEMCACHED_DISCOVERY_HOST

--- a/charts/wordpress-site/templates/wordpress.yaml
+++ b/charts/wordpress-site/templates/wordpress.yaml
@@ -37,10 +37,8 @@ spec:
   {{- if and .Values.media .Values.media.gcs }}
   media:
     gcs:
-      bucket: {{ .Values.media.gcs.bucket }}
-      {{- if .Values.media.gcs.prefix }}
-      prefix: {{ default "" .Values.media.gcs.prefix }}
-      {{- end }}
+      bucket: {{ required "A valid media.gcs.bucket is required!" .Values.media.gcs.bucket | quote }}
+      prefix: {{ default "" .Values.media.gcs.prefix | quote }}
       env:
         - name: GOOGLE_CREDENTIALS
           valueFrom:
@@ -48,7 +46,7 @@ spec:
               name: {{ include "wordpress-site.fullname" . }}
               key: google_application_credentials.json
         - name: GOOGLE_PROJECT_ID
-          value: {{ .Values.media.gcs.project }}
+          value: {{ required "A valid media.gcs.project is required!" .Values.media.gcs.project | quote }}
   {{- end }}
   env:
     - name: MEMCACHED_DISCOVERY_HOST

--- a/charts/wordpress-site/values.yaml
+++ b/charts/wordpress-site/values.yaml
@@ -39,6 +39,8 @@ code:
 media: {}
   #  Store media library in a Google Cloud Storage bucket
   #  gcs:
+  #    # google cloud project
+  #    project: staging
   #    # bucket name
   #    bucket: calins-wordpress-runtime-playground
   #    # use a prefix inside the bucket to store the media files

--- a/charts/wordpress-site/values.yaml
+++ b/charts/wordpress-site/values.yaml
@@ -45,6 +45,8 @@ media: {}
   #    bucket: calins-wordpress-runtime-playground
   #    # use a prefix inside the bucket to store the media files
   #    prefix: mysite/
+  #    # credentials to access Google Cloud Storage
+  #    google_credentials: >
 
 mysql:
   mysqlConf: {}


### PR DESCRIPTION
Adds multiple options for configuring GCS:
   * avoid using an empty `prefix` for gcs buckets
   * add `project` because is a required property for `wordpress-operator`
   * add an example of how to configure `google_credentials`